### PR TITLE
WIP: 1.5 Bugfixes

### DIFF
--- a/addon-sidaneThreadmarks.xml
+++ b/addon-sidaneThreadmarks.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<addon addon_id="sidaneThreadmarks" title="Threadmarks" version_string="1.5.0" version_id="1050022" url="https://xenforo.com/community/resources/threadmarks.3939/" install_callback_class="Sidane_Threadmarks_Install" install_callback_method="install" uninstall_callback_class="Sidane_Threadmarks_Install" uninstall_callback_method="uninstall">
+<addon addon_id="sidaneThreadmarks" title="Threadmarks" version_string="1.5.0" version_id="1050023" url="https://xenforo.com/community/resources/threadmarks.3939/" install_callback_class="Sidane_Threadmarks_Install" install_callback_method="install" uninstall_callback_class="Sidane_Threadmarks_Install" uninstall_callback_method="uninstall">
   <admin_navigation>
     <navigation navigation_id="sidane_tm_categories" parent_navigation_id="threadsPosts" display_order="5" link="threadmark-categories" admin_permission_id="sidane_threadmarks" debug_only="0" hide_no_children="0"/>
   </admin_navigation>
@@ -153,6 +153,9 @@
     <phrase title="moderator_log_post_create_threadmark" version_id="3" version_string="1.1"><![CDATA[Threadmark '{label}' created]]></phrase>
     <phrase title="moderator_log_post_delete_threadmark" version_id="3" version_string="1.1"><![CDATA[Threadmark '{label}' deleted]]></phrase>
     <phrase title="moderator_log_post_update_threadmark" version_id="3" version_string="1.1"><![CDATA[Threadmark changed from '{old_label}' to '{new_label}']]></phrase>
+    <phrase title="moderator_log_post_create_threadmark_2" version_id="1050023" version_string="1.5.0"><![CDATA[Threadmark '{category}: {label}' created]]></phrase>
+    <phrase title="moderator_log_post_delete_threadmark_2" version_id="1050023" version_string="1.5.0"><![CDATA[Threadmark '{category}: {label}' deleted]]></phrase>
+    <phrase title="moderator_log_post_update_threadmark_2" version_id="1050023" version_string="1.5.0"><![CDATA[Threadmark changed from '{old_category}: {old_label}' to '{new_category}: {new_label}']]></phrase>
     <phrase title="most_recent_threadmarks" version_id="1" version_string="1.0"><![CDATA[Most recent threadmarks]]></phrase>
     <phrase title="option_group_sidaneThreadmarks" version_id="1" version_string="1.0"><![CDATA[Threadmarks]]></phrase>
     <phrase title="option_group_sidaneThreadmarks_description" version_id="1" version_string="1.0"><![CDATA[]]></phrase>

--- a/upload/js/sidane/threadmarks/full/threadmarks.js
+++ b/upload/js/sidane/threadmarks/full/threadmarks.js
@@ -274,6 +274,8 @@ var Sidane = Sidane || {};
             {'speed': XenForo.speed.fast}
           );
           overlay.load();
+
+          this.$tree.closest('.xenOverlay').remove();
         }
         else
         {

--- a/upload/library/Sidane/Threadmarks/ControllerHelper/Threadmarks.php
+++ b/upload/library/Sidane/Threadmarks/ControllerHelper/Threadmarks.php
@@ -39,7 +39,7 @@ class Sidane_Threadmarks_ControllerHelper_Threadmarks extends XenForo_Controller
 
     foreach ($threadmarkCategories as $threadmarkCategoryId => &$threadmarkCategory)
     {
-      if (!isset($threadmarkCategoryPositions[$threadmarkCategoryId]))
+      if (isset($threadmarkCategoryPositions[$threadmarkCategoryId]))
       {
         $threadmarkCategory['count'] = $threadmarkCategoryPositions[$threadmarkCategoryId] + 1;
       }

--- a/upload/library/Sidane/Threadmarks/XenForo/ControllerPublic/Post.php
+++ b/upload/library/Sidane/Threadmarks/XenForo/ControllerPublic/Post.php
@@ -22,6 +22,11 @@ class Sidane_Threadmarks_XenForo_ControllerPublic_Post extends XFCP_Sidane_Threa
       );
     }
 
+    $threadmarkCategories = $threadmarksModel->getAllThreadmarkCategories();
+    $threadmarkCategories = $threadmarksModel->prepareThreadmarkCategories(
+      $threadmarkCategories
+    );
+
     if ($this->_request->isPost())
     {
       $input = $this->_input->filter(array(
@@ -51,13 +56,19 @@ class Sidane_Threadmarks_XenForo_ControllerPublic_Post extends XFCP_Sidane_Threa
 
           $phrase = 'threadmark_deleted';
 
+          $existingCategoryId = $existingThreadmark['threadmark_category_id'];
+          $existingCategory = 'Unknown Category';
+          if (!empty($threadmarkCategories[$existingCategoryId])) {
+            $existingCategory = $threadmarkCategories[$existingCategoryId];
+          }
+
           XenForo_Model_Log::logModeratorAction(
             'post',
             $post,
-            'delete_threadmark',
+            'delete_threadmark_2',
             array(
-              'label'                  => $existingThreadmark['label'],
-              'threadmark_category_id' => $existingThreadmark['threadmark_category_id']
+              'category' => (string) $existingCategory['title'],
+              'label'    => $existingThreadmark['label']
             ),
             $thread
           );
@@ -80,15 +91,27 @@ class Sidane_Threadmarks_XenForo_ControllerPublic_Post extends XFCP_Sidane_Threa
 
           $phrase = 'threadmark_updated';
 
+          $existingCategoryId = $existingThreadmark['threadmark_category_id'];
+          $existingCategory = 'Unknown Category';
+          if (!empty($threadmarkCategories[$existingCategoryId])) {
+            $existingCategory = $threadmarkCategories[$existingCategoryId];
+          }
+
+          $newCategoryId = $input['threadmark_category_id'];
+          $newCategory = 'Unknown Category';
+          if (!empty($threadmarkCategories[$newCategoryId])) {
+            $newCategory = $threadmarkCategories[$newCategoryId];
+          }
+
           XenForo_Model_Log::logModeratorAction(
             'post',
             $post,
-            'update_threadmark',
+            'update_threadmark_2',
             array(
-              'old_label'                  => $existingThreadmark['label'],
-              'new_label'                  => $input['label'],
-              'old_threadmark_category_id' => $existingThreadmark['threadmark_category_id'],
-              'new_threadmark_category_id' => $input['threadmark_category_id']
+              'old_category' => (string) $existingCategory['title'],
+              'old_label'    => $existingThreadmark['label'],
+              'new_category' => (string) $newCategory['title'],
+              'new_label'    => $input['label']
             ),
             $thread
           );
@@ -122,14 +145,22 @@ class Sidane_Threadmarks_XenForo_ControllerPublic_Post extends XFCP_Sidane_Threa
           $position,
           $resetNesting
         );
+
         $phrase = 'threadmark_created';
+
+        $categoryId = $input['threadmark_category_id'];
+        $category = 'Unknown Category';
+        if (!empty($threadmarkCategories[$categoryId])) {
+          $category = $threadmarkCategories[$categoryId];
+        }
+
         XenForo_Model_Log::logModeratorAction(
           'post',
           $post,
-          'create_threadmark',
+          'create_threadmark_2',
           array(
-            'label'                  => $input['label'],
-            'threadmark_category_id' => $input['threadmark_category_id']
+            'category' => (string) $category['title'],
+            'label'    => $input['label']
           ),
           $thread
         );
@@ -142,10 +173,6 @@ class Sidane_Threadmarks_XenForo_ControllerPublic_Post extends XFCP_Sidane_Threa
     }
     else
     {
-      $threadmarkCategories = $threadmarksModel->getAllThreadmarkCategories();
-      $threadmarkCategories = $threadmarksModel->prepareThreadmarkCategories(
-        $threadmarkCategories
-      );
       $threadmarkCategoryOptions = $threadmarksModel
         ->getThreadmarkCategoryOptions($threadmarkCategories, true);
 


### PR DESCRIPTION
Addresses outstanding issues in: https://github.com/sidane/xenforo-threadmarks/pull/54

- [x] Flipping between edit/save threadmark ordering will create a number of overlays in the background which are not cleaned up, not a major issue but is effectively a memory leak
- [x] Moderator log support when editing a Threadmark's category, the original category isn't record and looks like; Xon - Threadmark changed from 'Alert: Alright so' to 'Alert: Alright so'
- [x] Include threadmark total per category in dropdown, as users use this as an indicator
- [ ] On the threadmark index, each category should have a stats block at the top. Authors, count total (and room to insert word count totals)
- [ ] Per-thread category information should be more easily extendable (ie so I can stuff per threadmark category wordcounts in there).